### PR TITLE
Switch to msgpack instead of json

### DIFF
--- a/ELiDE/ELiDE/board/pawn.py
+++ b/ELiDE/ELiDE/board/pawn.py
@@ -32,7 +32,6 @@ class Pawn(PawnSpot):
     _touch_oy_diff = NumericProperty()
     _touch_opos_diff = ReferenceListProperty(_touch_ox_diff, _touch_oy_diff)
     _touch = ObjectProperty(None, allownone=True)
-    travel_on_drop = BooleanProperty(False)
     loc_name = ObjectProperty()
     next_loc_name = ObjectProperty(None, allownone=True)
     thing = AliasProperty(
@@ -140,11 +139,6 @@ class Pawn(PawnSpot):
         return True
 
     def on_touch_up(self, touch):
-        """See if I've been dropped on a :class:`Spot`. If so, command the
-        underlying :class:`Thing` to either travel there or teleport
-        there. Otherwise, snap back to my present location.
-
-        """
         if touch.grab_current != self:
             return False
         if hasattr(self.parent, 'place') and hasattr(self, '_pospawn_unbound'):
@@ -165,13 +159,14 @@ class Pawn(PawnSpot):
         if myplace != theirplace:
             if hasattr(self, '_start'):
                 del self._start
-            if self.travel_on_drop:
-                self.thing.travel_to(new_spot.name)
-            else:
+            if not self.dispatch('on_drop', new_spot):
                 self.loc_name = new_spot.name
         self.parent.remove_widget(self)
         new_spot.add_widget(self)
         return True
+
+    def on_drop(self, spot):
+        pass
 
     def __repr__(self):
         """Give my ``thing``'s name and its location's name."""

--- a/ELiDE/ELiDE/charmenu.py
+++ b/ELiDE/ELiDE/charmenu.py
@@ -137,7 +137,7 @@ class CharMenu(BoxLayout):
 
     def new_character(self, but):
         charn = try_load(
-            self.app.engine.json_load,
+            self.app.engine.unpack,
             self.app.chars.ids.newname.text
         )
         self.app.select_character(self.app.engine.new_character(charn))

--- a/ELiDE/ELiDE/screen.py
+++ b/ELiDE/ELiDE/screen.py
@@ -64,7 +64,7 @@ class StatListPanel(BoxLayout):
             del self.proxy[k]
         else:
             try:
-                vv = self.engine.json_load(v)
+                vv = self.engine.unpack(v)
             except (TypeError, ValueError):
                 vv = v
             self.proxy[k] = vv

--- a/ELiDE/ELiDE/statcfg.py
+++ b/ELiDE/ELiDE/statcfg.py
@@ -214,7 +214,7 @@ class StatScreen(Screen):
             self.proxy[key] \
                 = self.statlist.mirror[key] \
                 = self.statcfg.mirror[key] \
-                = self.engine.json_load(value)
+                = self.engine.unpack(value)
         except (TypeError, ValueError):
             self.proxy[key] \
                 = self.statlist.mirror[key] \

--- a/ELiDE/ELiDE/statlist.py
+++ b/ELiDE/ELiDE/statlist.py
@@ -247,7 +247,7 @@ class BaseStatListView(RecycleView):
             del self.mirror[k]
         else:
             try:
-                vv = self.engine.json_load(v)
+                vv = self.engine.unpack(v)
             except (TypeError, ValueError):
                 vv = v
             self.proxy[k] = self.mirror[k] = vv

--- a/LiSE/LiSE/examples/sickle.py
+++ b/LiSE/LiSE/examples/sickle.py
@@ -186,9 +186,11 @@ def sickle_cell_test(
         )
     )
 
-try:
-    remove('LiSEworld.db')
-except OSError:
-    pass
-with Engine('LiSEworld.db', random_seed=69105) as engine:
-    sickle_cell_test(engine)
+
+if __name__ == '__main__':
+    try:
+        remove('LiSEworld.db')
+    except OSError:
+        pass
+    with Engine('LiSEworld.db', random_seed=69105) as engine:
+        sickle_cell_test(engine)

--- a/LiSE/LiSE/handle.py
+++ b/LiSE/LiSE/handle.py
@@ -9,10 +9,6 @@ from re import match
 from collections import defaultdict
 from functools import partial
 from importlib import import_module
-from allegedb.xjson import (
-    JSONReWrapper,
-    JSONListReWrapper
-)
 from .engine import Engine
 from .util import dict_delta, set_delta
 
@@ -90,11 +86,11 @@ class EngineHandle(object):
     def critical(self, message):
         self.log(CRITICAL, message)
 
-    def json_load(self, s):
-        return self._real.json_load(s)
+    def unpack(self, s):
+        return self._real.unpack(s)
 
-    def json_dump(self, o):
-        return self._real.json_dump(o)
+    def pack(self, o):
+        return self._real.pack(o)
 
     def time_locked(self):
         return hasattr(self._real, 'locktime')

--- a/LiSE/LiSE/query.py
+++ b/LiSE/LiSE/query.py
@@ -328,21 +328,21 @@ def slow_iter_turns_eval_cmp(qry, oper, start_branch=None, engine=None):
 
 
 class QueryEngine(allegedb.query.QueryEngine):
-    json_path = LiSE.__path__[0]
+    path = LiSE.__path__[0]
     IntegrityError = IntegrityError
     OperationalError = OperationalError
 
     def universals_dump(self):
         for key, branch, turn, tick, value in self.sql('universals_dump'):
-            yield self.json_load(key), branch, turn, tick, self.json_load(value)
+            yield self.unpack(key), branch, turn, tick, self.unpack(value)
 
     def rulebooks_dump(self):
         for rulebook, branch, turn, tick, rules in self.sql('rulebooks_dump'):
-            yield self.json_load(rulebook), branch, turn, tick, self.json_load(rules)
+            yield self.unpack(rulebook), branch, turn, tick, self.unpack(rules)
 
     def _rule_dump(self, typ):
         for rule, branch, turn, tick, lst in self.sql('rule_{}_dump'.format(typ)):
-            yield rule, branch, turn, tick, self.json_load(lst)
+            yield rule, branch, turn, tick, self.unpack(lst)
 
     def rule_triggers_dump(self):
         return self._rule_dump('triggers')
@@ -356,23 +356,23 @@ class QueryEngine(allegedb.query.QueryEngine):
     def characters_dump(self):
         for graph, typ in self.sql('graphs_dump'):
             if typ == 'DiGraph':
-                yield self.json_load(graph)
+                yield self.unpack(graph)
     characters = characters_dump
 
     def node_rulebook_dump(self):
         for character, node, branch, turn, tick, rulebook in self.sql('node_rulebook_dump'):
-            yield self.json_load(character), self.json_load(node), branch, turn, tick, self.json_load(rulebook)
+            yield self.unpack(character), self.unpack(node), branch, turn, tick, self.unpack(rulebook)
 
     def portal_rulebook_dump(self):
         for character, orig, dest, branch, turn, tick, rulebook in self.sql('portal_rulebook_dump'):
             yield (
-                self.json_load(character), self.json_load(orig), self.json_load(dest),
-                branch, turn, tick, self.json_load(rulebook)
+                self.unpack(character), self.unpack(orig), self.unpack(dest),
+                branch, turn, tick, self.unpack(rulebook)
             )
 
     def _charactery_rulebook_dump(self, qry):
         for character, branch, turn, tick, rulebook in self.sql(qry+'_rulebook_dump'):
-            yield self.json_load(character), branch, turn, tick, self.json_load(rulebook)
+            yield self.unpack(character), branch, turn, tick, self.unpack(rulebook)
 
     character_rulebook_dump = partialmethod(_charactery_rulebook_dump, 'character')
     avatar_rulebook_dump = partialmethod(_charactery_rulebook_dump, 'avatar')
@@ -382,26 +382,26 @@ class QueryEngine(allegedb.query.QueryEngine):
 
     def character_rules_handled_dump(self):
         for character, rulebook, rule, branch, turn, tick in self.sql('character_rules_handled_dump'):
-            yield self.json_load(character), self.json_load(rulebook), rule, branch, turn, tick
+            yield self.unpack(character), self.unpack(rulebook), rule, branch, turn, tick
 
     def character_rules_changes_dump(self):
         for (
                 character, rulebook, rule, branch, turn, tick, handled_branch, handled_turn
         ) in self.sql('character_rules_changes_dump'):
             yield (
-                self.json_load(character), self.json_load(rulebook),
+                self.unpack(character), self.unpack(rulebook),
                 rule, branch, turn, tick, handled_branch, handled_turn
             )
 
     def avatar_rules_handled_dump(self):
         for character, rulebook, rule, graph, avatar, branch, turn, tick in self.sql('avatar_rules_handled_dump'):
             yield (
-                self.json_load(character), self.json_load(rulebook), rule,
-                self.json_load(graph), self.json_load(avatar), branch, turn, tick
+                self.unpack(character), self.unpack(rulebook), rule,
+                self.unpack(graph), self.unpack(avatar), branch, turn, tick
             )
 
     def avatar_rules_changes_dump(self):
-        jl = self.json_load
+        jl = self.unpack
         for (
             character, rulebook, rule, graph, avatar, branch, turn, tick, handled_branch, handled_turn
         ) in self.sql('avatar_rules_changes_dump'):
@@ -412,10 +412,10 @@ class QueryEngine(allegedb.query.QueryEngine):
 
     def character_thing_rules_handled_dump(self):
         for character, rulebook, rule, thing, branch, turn, tick in self.sql('character_thing_rules_handled_dump'):
-            yield self.json_load(character), self.json_load(rulebook), rule, self.json_load(thing), branch, turn, tick
+            yield self.unpack(character), self.unpack(rulebook), rule, self.unpack(thing), branch, turn, tick
 
     def character_thing_rules_changes_dump(self):
-        jl = self.json_load
+        jl = self.unpack
         for (
             character, rulebook, rule, thing, branch, turn, tick, handled_branch, handled_turn
         ) in self.sql('character_thing_rules_changes_dump'):
@@ -426,10 +426,10 @@ class QueryEngine(allegedb.query.QueryEngine):
 
     def character_place_rules_handled_dump(self):
         for character, rulebook, rule, place, branch, turn, tick in self.sql('character_place_rules_handled_dump'):
-            yield self.json_load(character), self.json_load(rulebook), rule, self.json_load(place), branch, turn, tick
+            yield self.unpack(character), self.unpack(rulebook), rule, self.unpack(place), branch, turn, tick
 
     def character_place_rules_changes_dump(self):
-        jl = self.json_load
+        jl = self.unpack
         for (
             character, rulebook, rule, place, branch, turn, tick, handled_branch, handled_turn
         ) in self.sql('character_place_rules_changes_dump'):
@@ -441,12 +441,12 @@ class QueryEngine(allegedb.query.QueryEngine):
     def character_portal_rules_handled_dump(self):
         for character, rulebook, rule, orig, dest, branch, turn, tick in self.sql('character_portal_rules_handled_dump'):
             yield (
-                self.json_load(character), self.json_load(rulebook), rule, self.json_load(orig), self.json_load(dest),
+                self.unpack(character), self.unpack(rulebook), rule, self.unpack(orig), self.unpack(dest),
                 branch, turn, tick
             )
 
     def character_portal_rules_changes_dump(self):
-        jl = self.json_load
+        jl = self.unpack
         for (
             character, rulebook, rule, orig, dest, branch, turn, tick, handled_branch, handled_turn
         ) in self.sql('character_portal_rules_changes_dump'):
@@ -457,10 +457,10 @@ class QueryEngine(allegedb.query.QueryEngine):
 
     def node_rules_handled_dump(self):
         for character, node, rulebook, rule, branch, turn, tick in self.sql('node_rules_handled_dump'):
-            yield self.json_load(character), self.json_load(node), self.json_load(rulebook), rule, branch, turn, tick
+            yield self.unpack(character), self.unpack(node), self.unpack(rulebook), rule, branch, turn, tick
 
     def node_rules_changes_dump(self):
-        jl = self.json_load
+        jl = self.unpack
         for (
                 character, node, rulebook, rule, branch, turn, tick, handled_branch, handled_turn
         ) in self.sql('node_rules_changes_dump'):
@@ -472,12 +472,12 @@ class QueryEngine(allegedb.query.QueryEngine):
     def portal_rules_handled_dump(self):
         for character, orig, dest, rulebook, rule, branch, turn, tick in self.sql('portal_rules_handled_dump'):
             yield (
-                self.json_load(character), self.json_load(orig), self.json_load(dest),
-                self.json_load(rulebook), rule, branch, turn, tick
+                self.unpack(character), self.unpack(orig), self.unpack(dest),
+                self.unpack(rulebook), rule, branch, turn, tick
             )
 
     def portal_rules_changes_dump(self):
-        jl = self.json_load
+        jl = self.unpack
         for (
             character, orig, dest, rulebook, rule, branch, turn, tick, handled_branch, handled_turn
         ) in self.sql('portal_rules_changes_dump'):
@@ -488,28 +488,28 @@ class QueryEngine(allegedb.query.QueryEngine):
 
     def senses_dump(self):
         for character, sense, branch, turn, tick, function in self.sql('senses_dump'):
-            yield self.json_load(character), sense, branch, turn, tick, function
+            yield self.unpack(character), sense, branch, turn, tick, function
 
     def things_dump(self):
         for character, thing, branch, turn, tick, location, next_location in self.sql('things_dump'):
             yield (
-                self.json_load(character), self.json_load(thing), branch, turn, tick,
-                self.json_load(location), self.json_load(next_location) if next_location else None
+                self.unpack(character), self.unpack(thing), branch, turn, tick,
+                self.unpack(location), self.unpack(next_location) if next_location else None
             )
 
     def avatars_dump(self):
         for character_graph, avatar_graph, avatar_node, branch, turn, tick, is_av in self.sql('avatars_dump'):
             yield (
-                self.json_load(character_graph), self.json_load(avatar_graph),
-                self.json_load(avatar_node), branch, turn, tick, is_av
+                self.unpack(character_graph), self.unpack(avatar_graph),
+                self.unpack(avatar_node), branch, turn, tick, is_av
             )
 
     def universal_set(self, key, branch, turn, tick, val):
-        key, val = map(self.json_dump, (key, val))
+        key, val = map(self.pack, (key, val))
         self.sql('universals_insert', key, branch, turn, tick, val)
 
     def universal_del(self, key, branch, turn, tick):
-        key = self.json_dump(key)
+        key = self.pack(key)
         self.sql('universals_insert', key, branch, turn, tick, None)
 
     def comparison(
@@ -537,7 +537,7 @@ class QueryEngine(allegedb.query.QueryEngine):
             yield name
 
     def _set_rule_something(self, what, rule, branch, turn, tick, flist):
-        flist = self.json_dump(flist)
+        flist = self.pack(flist)
         return self.sql('rule_{}_insert'.format(what), rule, branch, turn, tick, flist)
 
     set_rule_triggers = partialmethod(_set_rule_something, 'triggers')
@@ -551,11 +551,11 @@ class QueryEngine(allegedb.query.QueryEngine):
         self.set_rule_actions(rule, branch, turn, tick, actions or [])
 
     def set_rulebook(self, name, branch, turn, tick, rules=None):
-        name, rules = map(self.json_dump, (name, rules or []))
+        name, rules = map(self.pack, (name, rules or []))
         self.sql('rulebooks_insert', name, branch, turn, tick, rules)
 
     def _set_rulebook_on_character(self, rbtyp, char, branch, turn, tick, rb):
-        char, rb = map(self.json_dump, (char, rb))
+        char, rb = map(self.pack, (char, rb))
         self.sql(rbtyp + '_rulebook_insert', char, branch, turn, tick, rb)
 
     set_character_rulebook = partialmethod(_set_rulebook_on_character, 'character')
@@ -566,7 +566,7 @@ class QueryEngine(allegedb.query.QueryEngine):
 
     def rulebooks(self):
         for book in self.sql('rulebooks'):
-            yield self.json_load(book)
+            yield self.unpack(book)
 
     def exist_node(self, character, node, branch, turn, tick, extant, keep_rulebook=False):
         super().exist_node(character, node, branch, turn, tick, extant)
@@ -583,13 +583,13 @@ class QueryEngine(allegedb.query.QueryEngine):
 
     def set_node_rulebook(self, character, node, branch, turn, tick, rulebook):
         (character, node, rulebook) = map(
-            self.json_dump, (character, node, rulebook)
+            self.pack, (character, node, rulebook)
         )
         return self.sql('node_rulebook_insert', character, node, branch, turn, tick, rulebook)
 
     def set_portal_rulebook(self, character, orig, dest, branch, turn, tick, rulebook):
         (character, orig, dest, rulebook) = map(
-            self.json_dump, (character, orig, dest, rulebook)
+            self.pack, (character, orig, dest, rulebook)
         )
         return self.sql(
             'portal_rulebook_insert',
@@ -606,7 +606,7 @@ class QueryEngine(allegedb.query.QueryEngine):
             self, character, rulebook, rule, branch, turn, tick
     ):
         (character, rulebook) = map(
-            self.json_dump, (character, rulebook)
+            self.pack, (character, rulebook)
         )
         return self.sql(
             'character_rules_handled_insert',
@@ -620,7 +620,7 @@ class QueryEngine(allegedb.query.QueryEngine):
 
     def handled_avatar_rule(self, character, graph, av, rulebook, rule, branch, turn, tick):
         character, graph, av, rulebook = map(
-            self.json_dump, (character, graph, av, rulebook)
+            self.pack, (character, graph, av, rulebook)
         )
         return self.sql(
             'avatar_rules_handled_insert',
@@ -638,7 +638,7 @@ class QueryEngine(allegedb.query.QueryEngine):
             self, character, node, rulebook, rule, branch, turn, tick
     ):
         (character, node, rulebook) = map(
-            self.json_dump, (character, node, rulebook)
+            self.pack, (character, node, rulebook)
         )
         return self.sql(
             'node_rules_handled_insert',
@@ -655,7 +655,7 @@ class QueryEngine(allegedb.query.QueryEngine):
             self, character, orig, dest, rulebook, rule, branch, turn, tick
     ):
         (character, orig, dest, rulebook) = map(
-            self.json_dump, (character, orig, dest, rulebook)
+            self.pack, (character, orig, dest, rulebook)
         )
         return self.sql(
             'portal_rules_handled_insert',
@@ -670,22 +670,22 @@ class QueryEngine(allegedb.query.QueryEngine):
         )
 
     def get_rulebook_char(self, rulemap, character):
-        character = self.json_dump(character)
+        character = self.pack(character)
         for (book,) in self.sql(
                 'rulebook_get_{}'.format(rulemap), character
         ):
-            return self.json_load(book)
+            return self.unpack(book)
         raise KeyError("No rulebook")
 
     def thing_loc_and_next_set(
             self, character, thing, branch, turn, tick, loc, nextloc
     ):
         (character, thing) = map(
-            self.json_dump,
+            self.pack,
             (character, thing)
         )
-        loc = self.json_dump(loc)
-        nextloc = self.json_dump(nextloc)
+        loc = self.pack(loc)
+        nextloc = self.pack(nextloc)
         self.sql('del_things_after', character, thing, branch, turn, turn, tick)
         self.sql(
             'things_insert',
@@ -700,7 +700,7 @@ class QueryEngine(allegedb.query.QueryEngine):
 
     def avatar_set(self, character, graph, node, branch, turn, tick, isav):
         (character, graph, node) = map(
-            self.json_dump, (character, graph, node)
+            self.pack, (character, graph, node)
         )
         self.sql(
             'del_avatars_after',
@@ -712,12 +712,12 @@ class QueryEngine(allegedb.query.QueryEngine):
 
     def rulebooks_rules(self):
         for (rulebook, rule) in self.sql('rulebooks_rules'):
-            yield map(self.json_load, (rulebook, rule))
+            yield map(self.unpack, (rulebook, rule))
 
     def rulebook_get(self, rulebook, idx):
-        return self.json_load(
+        return self.unpack(
             self.sql(
-                'rulebook_get', self.json_dump(rulebook), idx
+                'rulebook_get', self.pack(rulebook), idx
             ).fetchone()[0]
         )
 

--- a/LiSE/setup.py
+++ b/LiSE/setup.py
@@ -29,6 +29,7 @@ setup(
     },
     install_requires=[
         "allegedb>=0.11.0",
-        "astunparse>=1.5.0"
+        "astunparse>=1.5.0",
+        "u-msgpack-python>=2.4.1"
     ],
 )

--- a/allegedb/allegedb/__init__.py
+++ b/allegedb/allegedb/__init__.py
@@ -551,6 +551,9 @@ class ORM(object):
             return True
         return self.is_parent_of(parent, self._branches[child][0])
 
+    def _get_branch(self):
+        return self._obranch
+
     def _set_branch(self, v):
         curbranch, curturn, curtick = self.btt()
         if curbranch == v:
@@ -579,7 +582,10 @@ class ORM(object):
             else:
                 self._branches[v] = (curbranch, curturn, curtick, curturn, curtick)
         self._obranch = v
-    branch = property(lambda self: self._obranch, _set_branch)  # easier to override this way
+    branch = property(_get_branch, _set_branch)  # easier to override this way
+
+    def _get_turn(self):
+        return self._oturn
 
     def _set_turn(self, v):
         if v == self.turn:
@@ -605,7 +611,10 @@ class ORM(object):
             self._branches[branch] = parent, turn_start, tick_start, v, tick
         self._otick = tick
         self._oturn = v
-    turn = property(lambda self: self._oturn, _set_turn)  # easier to override this way
+    turn = property(_get_turn, _set_turn)  # easier to override this way
+
+    def _get_tick(self):
+        return self._otick
 
     def _set_tick(self, v):
         if not isinstance(v, int):
@@ -623,7 +632,7 @@ class ORM(object):
             if turn == turn_end and v > tick_end:
                 self._branches[branch] = parent, turn_start, tick_start, turn, v
         self._otick = v
-    tick = property(lambda self: self._otick, _set_tick)  # easier to override this way
+    tick = property(_get_tick, _set_tick)  # easier to override this way
 
     def btt(self):
         """Return the branch, turn, and tick."""

--- a/allegedb/allegedb/__init__.py
+++ b/allegedb/allegedb/__init__.py
@@ -111,6 +111,24 @@ class TimeSignal(Signal):
     def __str__(self):
         return str((self.engine.branch, self.engine.turn))
 
+    def __eq__(self, other):
+        return tuple(self) == other
+
+    def __ne__(self, other):
+        return tuple(self) != other
+
+    def __gt__(self, other):
+        return tuple(self) > other
+
+    def __ge__(self, other):
+        return tuple(self) >= other
+
+    def __lt__(self, other):
+        return tuple(self) < other
+
+    def __le__(self, other):
+        return tuple(self) <= other
+
 
 class TimeSignalDescriptor:
     __doc__ = TimeSignal.__doc__

--- a/allegedb/allegedb/__init__.py
+++ b/allegedb/allegedb/__init__.py
@@ -222,8 +222,14 @@ def setedgeval(delta, is_multigraph, graph, orig, dest, idx, key, value):
         delta.setdefault(graph, {}).setdefault('edge_val', {})\
             .setdefault(orig, {}).setdefault(dest, {})[key] = value
 
+# TODO: cancel changes that would put something back to where it was at the start
+# This will complicate the update_window functions though, and I don't think it'll
+# improve much apart from a bit of efficiency in that the deltas are smaller
+# sometimes.
+
 
 def update_window(turn_from, tick_from, turn_to, tick_to, updfun, branchd):
+    """Iterate over a window of time in ``branchd`` and call ``updfun`` on the values"""
     if turn_from in branchd:
         # Not including the exact tick you started from because deltas are *changes*
         for past_state in branchd[turn_from][tick_from+1:]:
@@ -238,6 +244,7 @@ def update_window(turn_from, tick_from, turn_to, tick_to, updfun, branchd):
 
 
 def update_backward_window(turn_from, tick_from, turn_to, tick_to, updfun, branchd):
+    """Iterate backward over a window of time in ``branchd`` and call ``updfun`` on the values"""
     if turn_from in branchd:
         for future_state in reversed(branchd[turn_from][:tick_from]):
             updfun(*future_state)

--- a/allegedb/allegedb/__init__.py
+++ b/allegedb/allegedb/__init__.py
@@ -484,7 +484,7 @@ class ORM(object):
         if not hasattr(self, 'query'):
             self.query = self.query_engine_cls(
                 dbstring, connect_args, alchemy,
-                getattr(self, 'json_dump', None), getattr(self, 'json_load', None)
+                getattr(self, 'pack', None), getattr(self, 'unpack', None)
             )
         self.query.initdb()
         # in case this is the first startup
@@ -808,4 +808,4 @@ class ORM(object):
                 yield child
 
 
-__all__ = [ORM, 'graph', 'query', 'xjson']
+__all__ = [ORM, 'graph', 'query']

--- a/allegedb/allegedb/graph.py
+++ b/allegedb/allegedb/graph.py
@@ -5,12 +5,7 @@ from networkx.exception import NetworkXError
 from blinker import Signal
 from collections import MutableMapping, defaultdict
 from operator import attrgetter
-from .xjson import (
-    JSONWrapper,
-    JSONListWrapper,
-    JSONReWrapper,
-    JSONListReWrapper
-)
+from .wrap import DictWrapper, ListWrapper
 
 
 def getatt(attribute_name):
@@ -86,9 +81,9 @@ class AbstractEntityMapping(NeatMapping, Signal):
         """
         def wrapval(v):
             if isinstance(v, list):
-                return JSONListReWrapper(self, key, v)
+                return ListWrapper(self, key, v)
             elif isinstance(v, dict):
-                return JSONReWrapper(self, key, v)
+                return DictWrapper(self, key, v)
             else:
                 return v
 

--- a/allegedb/allegedb/test.py
+++ b/allegedb/allegedb/test.py
@@ -167,7 +167,7 @@ class CompiledQueriesTest(AllegedTest):
         self.assertTrue(hasattr(self.engine.query, 'alchemist'))
         self.assertTrue(isinstance(self.engine.query.alchemist, Alchemist))
         from json import load
-        with open(self.engine.query.json_path + '/sqlite.json', 'r') as jsonfile:
+        with open(self.engine.query.path + '/sqlite.json', 'r') as jsonfile:
             precompiled = load(jsonfile)
         self.assertEqual(
             precompiled.keys(), self.engine.query.alchemist.sql.keys()


### PR DESCRIPTION
The json serializer was a terrible hack to work around the standard library's inability to use tuples as keys. u-msgpack-python supports this natively, and may have performance benefits as well.

allegedb now uses repr and ast.literal_eval