### PR TITLE
Cache contents, generally make caching more aggressive

### DIFF
--- a/ELiDE/ELiDE/dialog.py
+++ b/ELiDE/ELiDE/dialog.py
@@ -162,7 +162,7 @@ class DialogLayout(FloatLayout):
 
     def _pull(self, *args, key, value):
         if key == 'last_result':
-            self.todo = value or []
+            self.todo = value if value and isinstance(value, list) else []
         elif key == 'last_result_idx':
             self.idx = value
 

--- a/LiSE/LiSE/character.py
+++ b/LiSE/LiSE/character.py
@@ -131,10 +131,9 @@ class AbstractCharacter(MutableMapping):
             n = 0
             while name + str(n) in self.node:
                 n += 1
-        elif name in self.node:
-            raise KeyError("Already have a thing named {}".format(name))
-        self.add_thing(name + str(n), location, **kwargs)
-        return self.thing[name]
+            self.add_thing(name + str(n), location, **kwargs)
+            return self.thing[name]
+        raise KeyError("Already have a thing named {}".format(name))
 
     @abstractmethod
     def thing2place(self, name): pass

--- a/LiSE/LiSE/character.py
+++ b/LiSE/LiSE/character.py
@@ -127,9 +127,12 @@ class AbstractCharacter(MutableMapping):
         if name not in self.node:
             self.add_thing(name, location, **kwargs)
             return self.thing[name]
-        n = 0
-        while name + str(n) in self.node:
-            n += 1
+        if isinstance(name, str):
+            n = 0
+            while name + str(n) in self.node:
+                n += 1
+        elif name in self.node:
+            raise KeyError("Already have a thing named {}".format(name))
         self.add_thing(name + str(n), location, **kwargs)
         return self.thing[name]
 

--- a/LiSE/LiSE/character.py
+++ b/LiSE/LiSE/character.py
@@ -1922,7 +1922,7 @@ class Character(DiGraph, AbstractCharacter, RuleFollower):
         self.add_node(name, **kwargs)
         if isinstance(location, Node):
             location = location.name
-        self.place2thing(name, location)
+        self.place2thing(name, location, kwargs.get('next_location'))
 
     def add_things_from(self, seq, **attrs):
         for tup in seq:
@@ -1934,14 +1934,14 @@ class Character(DiGraph, AbstractCharacter, RuleFollower):
                 kwargs['next_location'] = next_loc
             self.add_thing(name, location, **kwargs)
 
-    def place2thing(self, name, location):
+    def place2thing(self, name, location, next_location=None):
         """Turn a Place into a Thing with the given.
         
         It will keep all its attached Portals.
 
         """
         self.engine._set_thing_loc_and_next(
-            self.name, name, location, None
+            self.name, name, location, next_location
         )
         if (self.name, name) in self.engine._node_objs:
             del self.engine._node_objs[self.name, name]

--- a/LiSE/LiSE/engine.py
+++ b/LiSE/LiSE/engine.py
@@ -759,26 +759,6 @@ class Engine(AbstractEngine, gORM):
         self.rule.query.rulebook_del_all(rulebook)
         del self._rulebooks_cache._data[rulebook]
 
-    def _set_node_rulebook(self, character, node, rulebook):
-        try:
-            if rulebook == self._nodes_rulebooks_cache.retrieve(character, node, *self.engine.btt()):
-                return
-        except KeyError:
-            pass
-        branch, turn, tick = self.engine.nbtt()
-        self._nodes_rulebooks_cache.store(character, node, branch, turn, tick, rulebook)
-        self.engine.query.set_node_rulebook(character, node, branch, turn, tick, rulebook)
-
-    def _set_portal_rulebook(self, character, orig, dest, rulebook):
-        try:
-            if rulebook == self._portals_rulebooks_cache.retrieve(character, orig, dest, *self.engine.btt()):
-                return
-        except KeyError:
-            pass
-        branch, turn, tick = self.engine.nbtt()
-        self._portals_rulebooks_cache.store(character, orig, dest, branch, turn, tick, rulebook)
-        self.query.set_portal_rulebook(character, orig, dest, branch, turn, tick, rulebook)
-
     def _remember_avatarness(
             self, character, graph, node,
             is_avatar=True, branch=None, turn=None,

--- a/LiSE/LiSE/node.py
+++ b/LiSE/LiSE/node.py
@@ -104,9 +104,14 @@ class UserMapping(Mapping):
 class NodeContentValues(ValuesView):
     def __iter__(self):
         node = self._mapping.node
-        for thing in node.character.thing.values():
-            if thing.location == node:
-                yield thing
+        nodem = node.character.node
+        try:
+            for name in node.engine._node_contents_cache.retrieve(
+                    node.character.name, node.name, *node.engine.btt()
+            ):
+                yield nodem[name]
+        except KeyError:
+            return
 
     def __contains__(self, item):
         return item.location == self._mapping.node
@@ -119,16 +124,20 @@ class NodeContent(Mapping):
         self.node = node
 
     def __iter__(self):
-        # TODO: cache this
-        for name, thing in self.node.character.thing.items():
-            if thing.location == self.node:
-                yield name
+        try:
+            yield from self.node.engine._node_contents_cache.retrieve(
+                self.node.character.name, self.node.name, *self.node.engine.btt()
+            )
+        except KeyError:
+            return
 
     def __len__(self):
-        n = 0
-        for thing in self:
-            n += 1
-        return n
+        try:
+            return len(self.node.engine._node_contents_cache.retrieve(
+                self.node.character.name, self.node.name, *self.node.engine.btt()
+            ))
+        except KeyError:
+            return 0
 
     def __contains__(self, item):
         try:

--- a/LiSE/LiSE/node.py
+++ b/LiSE/LiSE/node.py
@@ -265,12 +265,18 @@ class Node(allegedb.graph.Node, rule.RuleFollower):
             self._get_rulebook_name()
         )
 
-    def _set_rulebook_name(self, v):
-        self.engine._set_node_rulebook(
-            self.character.name,
-            self.name,
-            v
-        )
+    def _set_rulebook_name(self, rulebook):
+        character = self.character.name
+        node = self.name
+        cache = self.engine._nodes_rulebooks_cache
+        try:
+            if rulebook == cache.retrieve(character, node, *self.engine.btt()):
+                return
+        except KeyError:
+            pass
+        branch, turn, tick = self.engine.nbtt()
+        cache.store(character, node, branch, turn, tick, rulebook)
+        self.engine.query.set_node_rulebook(character, node, branch, turn, tick, rulebook)
 
     @property
     def portal(self):

--- a/LiSE/LiSE/portal.py
+++ b/LiSE/LiSE/portal.py
@@ -39,15 +39,20 @@ class PortalContent(Mapping):
         self.portal = portal
 
     def __iter__(self):
-        for name, thing in self.portal.character.thing.items():
-            if thing.location == self.portal.origin and thing.next_location == self.portal.destination:
-                yield name
+        try:
+            yield from self.portal.engine._portal_contents_cache.retrieve(
+                self.portal.orig, self.portal.dest, *self.portal.engine.btt()
+            )
+        except KeyError:
+            return
 
     def __len__(self):
-        i = 0
-        for name in iter(self):
-            i += 1
-        return i
+        try:
+            return len(self.portal.engine._portal_contents_cache.retrieve(
+                self.portal.orig, self.portal.dest, *self.portal.engine.btt())
+            )
+        except KeyError:
+            return 0
 
     def __contains__(self, item):
         try:

--- a/LiSE/LiSE/portal.py
+++ b/LiSE/LiSE/portal.py
@@ -67,8 +67,19 @@ class Portal(Edge, RuleFollower):
             self.character.name, self.orig, self.dest, *self.engine.btt()
         )
 
-    def _set_rulebook_name(self, n):
-        self.engine._set_portal_rulebook(self.character.name, self.orig, self.dest, n)
+    def _set_rulebook_name(self, rulebook):
+        character = self.character
+        orig = self.orig
+        dest = self.dest
+        cache = self.engine._portals_rulebooks_cache
+        try:
+            if rulebook == cache.retrieve(character, orig, dest, *self.engine.btt()):
+                return
+        except KeyError:
+            pass
+        branch, turn, tick = self.engine.nbtt()
+        cache.store(character, orig, dest, branch, turn, tick, rulebook)
+        self.engine.query.set_portal_rulebook(character, orig, dest, branch, turn, tick, rulebook)
 
     def _get_rule_mapping(self):
         return RuleMapping(self)

--- a/LiSE/LiSE/rule.py
+++ b/LiSE/LiSE/rule.py
@@ -590,7 +590,7 @@ class AllRuleBooks(MutableMapping, Signal):
         rb.extend(value)
 
     def __delitem__(self, key):
-        raise NotImplementedError
+        self.engine._del_rulebook(key)
 
 
 class AllRules(MutableMapping, Signal):

--- a/LiSE/LiSE/tests/test_contents.py
+++ b/LiSE/LiSE/tests/test_contents.py
@@ -1,0 +1,36 @@
+import pytest
+from LiSE.engine import Engine
+
+
+@pytest.fixture(scope='function')
+def chara():
+    with Engine(":memory:") as eng:
+        yield eng.new_character('chara')
+
+
+def test_many_things_in_place(chara):
+    place = chara.new_place(0)
+    things = [place.new_thing(i) for i in range(1, 10)]
+    for thing in things:
+        assert thing in place.contents()
+    for that in place.content:
+        assert place.content[that].location == place
+    things.sort(key=lambda th: th.name)
+    contents = sorted(place.contents(), key=lambda th: th.name)
+    assert things == contents
+
+
+def test_many_things_in_portal(chara):
+    chara.add_place(0)
+    chara.add_place(1)
+    port = chara.new_portal(0, 1)
+    things = []
+    for i in range(2, 10):
+        th = chara.new_thing(i, location=0, next_location=1)
+        things.append(th)
+    for thing in things:
+        assert thing in port.contents()
+        assert thing.name in port.content
+    things.sort(key=lambda th: th.name)
+    contents = sorted(port.contents(), key=lambda th: th.name)
+    assert things == contents

--- a/allegedb/allegedb/cache.py
+++ b/allegedb/allegedb/cache.py
@@ -249,11 +249,14 @@ class Cache(object):
             return keycache[keycache_key][turn][tick]
         if forward and keycache_key in keycache:
             # Take valid values from the past of a keycache and copy them forward, into the present.
+            # Assumes that time is only moving forward, never backward, never skipping any turns or ticks,
+            # and any changes to the world state are happening through allegedb proper, meaning they'll all get cached.
+            # In LiSE this means every change to the world state should happen inside of a call to
+            # ``Engine.next_turn`` in a rule.
             kc = keycache[keycache_key]
             try:
                 if turn not in kc:
-                    if tick == 0 and kc.rev_before(turn) == turn - 1:
-                        # We had valid keys a turn ago. Reuse those.
+                    if kc.rev_gettable(turn):
                         old_turn_kc = kc[turn]
                         new_turn_kc = FuturistWindowDict()
                         keys = old_turn_kc[old_turn_kc.end]

--- a/allegedb/allegedb/cache.py
+++ b/allegedb/allegedb/cache.py
@@ -178,7 +178,7 @@ class Cache(object):
         but still need to iterate through history to find the value.
 
         """
-        self.shallow = PickyDefaultDict(TurnDict)
+        self.shallow = PickyDefaultDict(SettingsTurnDict)
         """Less structured alternative to ``branches`` ."""
         self.shallower = PickyDefaultDict(WindowDict)
         """Even less structured alternative to ``shallow``."""
@@ -426,14 +426,18 @@ class Cache(object):
             assert turn in keys
             assert turn in shallow
             branchesturn = branches[turn]
-            assert branchesturn is keys[turn] is shallow[turn]
+            assert branchesturn is keys[turn]
             branchesturn.truncate(tick)
             branchesturn[tick] = value
+            shallowturn = shallow[turn]
+            shallowturn.truncate(tick)
+            shallowturn[tick] = value
         else:
             if new is None:
                 new = FuturistWindowDict()
                 new[tick] = value
-            branches[turn] = keys[turn] = shallow[turn] = new
+            branches[turn] = keys[turn] = new
+            shallow[turn] = {tick: value}
         self.shallower[parent+(entity, key, branch, turn)][tick] = value
         self.shallowest[parent+(entity, key, branch, turn, tick)] = value
 
@@ -501,6 +505,8 @@ class Cache(object):
                 else:
                     ret = brancs[r]
                     ret = ret[ret.end]
+                    self.shallow[entity+(key, branch)][turn][tick] = ret
+                    self.shallower[entity+(key, branch, turn)][tick] = ret
                     self.shallowest[args] = ret
                 return ret
         else:

--- a/allegedb/allegedb/cache.py
+++ b/allegedb/allegedb/cache.py
@@ -243,7 +243,8 @@ class Cache(object):
                     if ex.deleted:
                         return
 
-    def _get_keycachelike(self, keycache, keys, slow_iter_keys, parentity, branch, turn, tick, *, forward):
+    @staticmethod
+    def _get_keycachelike(keycache, keys, slow_iter_keys, parentity, branch, turn, tick, *, forward):
         keycache_key = parentity + (branch,)
         if keycache_key in keycache and turn in keycache[keycache_key] and tick in keycache[keycache_key][turn]:
             return keycache[keycache_key][turn][tick]

--- a/allegedb/allegedb/cache.py
+++ b/allegedb/allegedb/cache.py
@@ -501,6 +501,7 @@ class Cache(object):
                 else:
                     ret = brancs[r]
                     ret = ret[ret.end]
+                    self.shallowest[args] = ret
                 return ret
         else:
             raise KeyError


### PR DESCRIPTION
This adds new caches for the Node.contents() and Portal.contents() collections, making those much faster to iterate over; and relaxes some restrictions on the other caches that were preventing them from performing as well as they could.