### PR TITLE
Update README with Mac installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,22 @@ git submodule update
 pip3 install --user LiSE/ ELiDE/
 ```
 
+## Mac
+```
+# if you don't have python installed (Macs often come with in installed): 
+brew install python pip3
+# install the Kivy app framework
+brew install cython
+# ELiDE doesn't play movies, so disable gstreamer
+USE_GSTREAMER=0 pip3 install --user kivy
+# install LiSE and the ELiDE frontend
+git clone https://github.com/LogicalDash/LiSE.git
+cd LiSE
+git submodule init
+git submodule update
+pip3 install --user LiSE/ ELiDE/
+```
+
 You could now start the graphical frontend with ``python3 -mELiDE``, but this might not be very useful, as you don't
 have any world state to edit yet. You could laboriously assemble a gameworld by hand, but instead
 let's generate one, Parable of the Polygons by Nicky Case.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ pip3 install --user LiSE/ ELiDE/
 
 ## Mac
 ```
-# if you don't have python installed (Macs often come with in installed): 
+# if you don't have python 3 installed: 
 brew install python pip3
 # install the Kivy app framework
 brew install cython


### PR DESCRIPTION
NB I can't get the demo script to run and the grid doesn't work in ELiDE. This could be due to misinstalling (ie these instructions are wrong), or another error.

Here's the error I got:
```
ed@Eds-MacBook-Pro ~/p/LiSE (master)> python3 polygons.py
Traceback (most recent call last):
  File "/Users/ed/personal-dev/LiSE/polygons.py", line 1, in <module>
    from LiSE.character import grid_2d_8graphs
ImportError: cannot import name 'grid_2d_8graphs' from 'LiSE.character' (/Users/ed/Library/Python/3.9/lib/python/site-packages/LiSE/character.py)
```
