### PR TITLE
Rule Stepper

### DIFF
--- a/ELiDE/ELiDE/graph/arrow.py
+++ b/ELiDE/ELiDE/graph/arrow.py
@@ -287,7 +287,6 @@ class GraphArrowWidget(Widget):
     left_head_quad_vertices_fg = ListProperty(eight0s)
     right_head_quad_vertices_fg = ListProperty(eight0s)
     slope = NumericProperty(0.0, allownone=True)
-    y_intercept = NumericProperty(0)
     origin = ObjectProperty()
     destination = ObjectProperty()
     repointed = BooleanProperty(True)
@@ -533,7 +532,6 @@ class GraphArrowWidget(Widget):
             x2, y2, endx, endy, r
         )
         self.slope = self._get_slope()
-        self.y_intercept = self._get_b()
         self.repointed = True
 
     @trigger

--- a/ELiDE/ELiDE/screen.py
+++ b/ELiDE/ELiDE/screen.py
@@ -147,16 +147,19 @@ class TimePanel(BoxLayout):
         branch = self.ids.branchfield.text
         self.ids.branchfield.text = ''
         self.screen.app.branch = branch
+        self.ids.charmenu._switch_to_menu()
 
     def set_turn(self, *args):
         turn = int(self.ids.turnfield.text)
         self.ids.turnfield.text = ''
         self.screen.app.turn = turn
+        self.ids.charmenu._switch_to_menu()
 
     def set_tick(self, *args):
         tick = int(self.ids.tickfield.text)
         self.ids.tickfield.text = ''
         self.screen.app.tick = tick
+        self.ids.charmenu._switch_to_menu()
 
     def _upd_branch_hint(self, *args):
         self.ids.branchfield.hint_text = self.screen.app.branch
@@ -438,6 +441,7 @@ class MainScreen(Screen):
             tick=self.app._push_time
         )
         eng.next_turn(cb=partial(self._update_from_next_turn, cb=cb))
+        self.ids.charmenu._switch_to_menu()
 
     def switch_to_calendar(self, *args):
         self.app.update_calendar(self.calendar)
@@ -513,6 +517,14 @@ class CharMenuContainer(BoxLayout):
             self.add_widget(self.charmenu)
             self.button.text = 'Rule stepper'
         self.add_widget(self.button)
+
+    @trigger
+    def _switch_to_menu(self, *args):
+        if self.charmenu not in self.children:
+            self.clear_widgets()
+            self.add_widget(self.charmenu)
+            self.button.text = 'Rule stepper'
+            self.add_widget(self.button)
 
 
 Builder.load_string(

--- a/ELiDE/ELiDE/screen.py
+++ b/ELiDE/ELiDE/screen.py
@@ -43,6 +43,7 @@ from kivy.properties import (
     ReferenceListProperty,
     StringProperty
 )
+from .stepper import RuleStepper
 from .charmenu import CharMenu
 from .graph.board import GraphBoardView
 from .grid.board import GridBoardView
@@ -464,6 +465,52 @@ class MainScreen(Screen):
             self.switch_to_boardview()
 
 
+class CharMenuContainer(BoxLayout):
+    screen = ObjectProperty()
+    dummyplace = ObjectProperty()
+    dummything = ObjectProperty()
+    portaladdbut = ObjectProperty()
+
+    def __init__(self, **kwargs):
+        super(CharMenuContainer, self).__init__(**kwargs)
+        self.charmenu = CharMenu(
+            screen=self.screen,
+            size_hint_y=0.9
+        )
+        self.dummyplace = self.charmenu.dummyplace
+        self.charmenu.bind(dummyplace=self.setter('dummyplace'))
+        self.dummything = self.charmenu.dummything
+        self.charmenu.bind(dummything=self.setter('dummything'))
+        self.portaladdbut = self.charmenu.portaladdbut
+        self.charmenu.bind(portaladdbut=self.setter('portaladdbut'))
+        self.stepper = RuleStepper(size_hint_y=0.9)
+        self.button = Button(
+            on_release=self._toggle,
+            text='Rule stepper',
+            size_hint_y=0.1
+        )
+
+    def on_parent(self, *args):
+        if not self.screen or not hasattr(self, 'charmenu') or not hasattr(
+                self, 'stepper') or not hasattr(self, 'button'):
+            Clock.schedule_once(self.on_parent, 0)
+            return
+        self.add_widget(self.charmenu)
+        self.add_widget(self.button)
+
+    @trigger
+    def _toggle(self, *args):
+        if self.charmenu in self.children:
+            self.clear_widgets()
+            self.add_widget(self.stepper)
+            self.button.text = 'Menu'
+        else:
+            self.clear_widgets()
+            self.add_widget(self.charmenu)
+            self.button.text = 'Rule stepper'
+        self.add_widget(self.button)
+
+
 Builder.load_string(
     """
 #: import resource_find kivy.resources.resource_find
@@ -614,8 +661,9 @@ Builder.load_string(
         pos_hint: {'bot': 0}
         size_hint: (0.25, 0.2)
         disable_one_turn: root.tmp_block
-    CharMenu:
+    CharMenuContainer:
         id: charmenu
+        orientation: 'vertical'
         screen: root
         pos_hint: {'right': 1, 'top': 1}
         size_hint: (0.1, 1)

--- a/ELiDE/ELiDE/screen.py
+++ b/ELiDE/ELiDE/screen.py
@@ -508,7 +508,6 @@ class CharMenuContainer(BoxLayout):
             engine = self.screen.app.engine
             self.clear_widgets()
             self.stepper.from_rules_handled_turn(
-                self.screen.app.tick,
                 engine.handle('rules_handled_turn')
             )
             self.add_widget(self.stepper)

--- a/ELiDE/ELiDE/screen.py
+++ b/ELiDE/ELiDE/screen.py
@@ -490,7 +490,7 @@ class CharMenuContainer(BoxLayout):
         self.stepper = RuleStepper(size_hint_y=0.9)
         self.button = Button(
             on_release=self._toggle,
-            text='Rule stepper',
+            text='Rule\nstepper',
             size_hint_y=0.1
         )
 

--- a/ELiDE/ELiDE/screen.py
+++ b/ELiDE/ELiDE/screen.py
@@ -147,19 +147,19 @@ class TimePanel(BoxLayout):
         branch = self.ids.branchfield.text
         self.ids.branchfield.text = ''
         self.screen.app.branch = branch
-        self.ids.charmenu._switch_to_menu()
+        self.screen.charmenu._switch_to_menu()
 
     def set_turn(self, *args):
         turn = int(self.ids.turnfield.text)
         self.ids.turnfield.text = ''
         self.screen.app.turn = turn
-        self.ids.charmenu._switch_to_menu()
+        self.screen.charmenu._switch_to_menu()
 
     def set_tick(self, *args):
         tick = int(self.ids.tickfield.text)
         self.ids.tickfield.text = ''
         self.screen.app.tick = tick
-        self.ids.charmenu._switch_to_menu()
+        self.screen.charmenu._switch_to_menu()
 
     def _upd_branch_hint(self, *args):
         self.ids.branchfield.hint_text = self.screen.app.branch

--- a/ELiDE/ELiDE/screen.py
+++ b/ELiDE/ELiDE/screen.py
@@ -501,7 +501,11 @@ class CharMenuContainer(BoxLayout):
     @trigger
     def _toggle(self, *args):
         if self.charmenu in self.children:
+            engine = self.screen.app.engine
             self.clear_widgets()
+            self.stepper.from_rules_handled_turn(
+                engine.handle('rules_handled_turn')
+            )
             self.add_widget(self.stepper)
             self.button.text = 'Menu'
         else:

--- a/ELiDE/ELiDE/screen.py
+++ b/ELiDE/ELiDE/screen.py
@@ -508,6 +508,7 @@ class CharMenuContainer(BoxLayout):
             engine = self.screen.app.engine
             self.clear_widgets()
             self.stepper.from_rules_handled_turn(
+                self.screen.app.tick,
                 engine.handle('rules_handled_turn')
             )
             self.add_widget(self.stepper)

--- a/ELiDE/ELiDE/stepper.py
+++ b/ELiDE/ELiDE/stepper.py
@@ -116,7 +116,6 @@ class RulebookTypeLabel(Label):
 
 Builder.load_string("""
 <RuleStepper>:
-            # rules is a WindowDict, guaranteed to be sorted
     key_viewclass: 'widget'
     RecycleGridLayout:
         cols: 1

--- a/ELiDE/ELiDE/stepper.py
+++ b/ELiDE/ELiDE/stepper.py
@@ -115,8 +115,10 @@ class RulebookTypeLabel(Label):
 
 
 Builder.load_string("""
+#:import ScrollEffect kivy.effects.scroll.ScrollEffect
 <RuleStepper>:
     key_viewclass: 'widget'
+    effect_cls: ScrollEffect
     RecycleGridLayout:
         cols: 1
         size_hint_y: None

--- a/ELiDE/ELiDE/stepper.py
+++ b/ELiDE/ELiDE/stepper.py
@@ -33,7 +33,7 @@ class RuleStepper(RecycleView):
                 rulebook_per_entity = rbtyp in {'thing', 'place', 'portal'}
                 if not rulebook_per_entity:
                     if rulebook != last_rulebook:
-                        rulebook = last_rulebook
+                        last_rulebook = rulebook
                         data.append({
                             'widget': 'RulebookLabel',
                             'name': rulebook
@@ -89,5 +89,20 @@ Builder.load_string("""
     RecycleGridLayout:
         cols: 1
 <RuleStepperRuleButton>:
+    text: '>>>' + self.name
+    text_size: self.width, None
+    size: self.texture_size
+<EntityLabel>:
+    multiline: True
+    text: '>>' + str(self.name)
+    text_size: self.width, None
+    size: self.texture_size
+<RulebookLabel>:
+    text: '>' + str(self.name)
+    text_size: self.width, None
+    size: self.texture_size
+<RulebookTypeLabel>:
     text: self.name
+    text_size: self.width, None
+    size: self.texture_size
 """)

--- a/ELiDE/ELiDE/stepper.py
+++ b/ELiDE/ELiDE/stepper.py
@@ -89,20 +89,29 @@ Builder.load_string("""
     RecycleGridLayout:
         cols: 1
 <RuleStepperRuleButton>:
-    text: '>>>' + self.name
+    text: self.name
+    font_size: 14
     text_size: self.width, None
     size: self.texture_size
+    halign: 'center'
 <EntityLabel>:
     multiline: True
-    text: '>>' + str(self.name)
+    text: str(self.name)
     text_size: self.width, None
     size: self.texture_size
+    font_size: 14
+    padding_x: 8
 <RulebookLabel>:
-    text: '>' + str(self.name)
+    text: str(self.name)
     text_size: self.width, None
     size: self.texture_size
+    font_size: 14
+    bold: True
+    padding_x: 4
 <RulebookTypeLabel>:
     text: self.name
     text_size: self.width, None
+    font_size: 16
+    bold: True
     size: self.texture_size
 """)

--- a/ELiDE/ELiDE/stepper.py
+++ b/ELiDE/ELiDE/stepper.py
@@ -14,7 +14,7 @@ from kivy.graphics import Color, Line
 class RuleStepper(RecycleView):
     name = StringProperty()
 
-    def from_rules_handled_turn(self, start_tick, rules_handled_turn):
+    def from_rules_handled_turn(self, rules_handled_turn):
         data = []
         for rbtyp, rules in rules_handled_turn.items():
             if not rules:
@@ -26,7 +26,7 @@ class RuleStepper(RecycleView):
             last_entity = None
             last_rulebook = None
             # rules is a WindowDict, guaranteed to be sorted
-            prev_tick = start_tick
+            prev_tick = 0
             for tick, (entity, rulebook, rule) in rules.items():
                 rulebook_per_entity = rbtyp in {'thing', 'place', 'portal'}
                 if not rulebook_per_entity:

--- a/ELiDE/ELiDE/stepper.py
+++ b/ELiDE/ELiDE/stepper.py
@@ -55,7 +55,8 @@ class RuleStepper(RecycleView):
                     'widget': 'RuleStepperRuleButton',
                     'name': rule,
                     'start_tick': tick,
-                    'end_tick': None
+                    'end_tick': None,
+                    'height': 28
                 })
             if data:
                 prev = data[-1]
@@ -103,7 +104,6 @@ Builder.load_string("""
     text: self.name
     font_size: 14
     text_size: self.width, None
-    height: self.texture_size[1] * 2
     halign: 'center'
     tick: app.tick
     set_tick: app.set_tick

--- a/ELiDE/ELiDE/stepper.py
+++ b/ELiDE/ELiDE/stepper.py
@@ -1,0 +1,91 @@
+from kivy.properties import (
+    NumericProperty,
+    ObjectProperty,
+    StringProperty
+)
+from kivy.uix.button import Button
+from kivy.uix.label import Label
+from kivy.uix.recycleview import RecycleView
+from kivy.lang import Builder
+
+
+class RuleStepper(RecycleView):
+    name = StringProperty()
+
+    def from_rules_handled_turn(self, rules_handled_turn):
+        data = []
+        for rbtyp, rules in rules_handled_turn.items():
+            if not rules:
+                continue
+            data.append({
+                'widget': 'RulebookTypeLabel',
+                'name': rbtyp
+            })
+            last_entity = None
+            last_rulebook = None
+            # rules is a WindowDict, guaranteed to be sorted
+            for tick, (entity, rulebook, rule) in rules.items():
+                if data:
+                    prev = data[-1]
+                    assert prev['widget'] == 'RuleLabel'
+                    assert prev['end_tick'] is None
+                    prev['end_tick'] = tick - 1
+                rulebook_per_entity = rbtyp in {'thing', 'place', 'portal'}
+                if not rulebook_per_entity:
+                    if rulebook != last_rulebook:
+                        rulebook = last_rulebook
+                        data.append({
+                            'widget': 'RulebookLabel',
+                            'name': rulebook
+                        })
+                if entity != last_entity:
+                    last_entity = entity
+                    data.append({
+                        'widget': 'EntityLabel',
+                        'name': entity
+                    })
+                if rulebook_per_entity:
+                    if rulebook != last_rulebook:
+                        rulebook = last_rulebook
+                        data.append({
+                            'widget': 'RulebookLabel',
+                            'name': rulebook
+                        })
+                data.append({
+                    'widget': 'RuleLabel',
+                    'name': rule,
+                    'start_tick': tick,
+                    'end_tick': None
+                })
+            if data:
+                prev = data[-1]
+                assert prev['widget'] == 'RuleLabel'
+                assert prev['end_tick'] is None
+                prev['end_tick'] = tick - 1
+        self.data = data
+
+
+class RuleButton(Button):
+    name = StringProperty()
+    start_tick = NumericProperty()
+    end_tick = NumericProperty()
+
+
+class EntityLabel(Label):
+    name = ObjectProperty()
+
+
+class RulebookLabel(Label):
+    name = ObjectProperty()  # rulebooks may have tuples for names
+
+
+class RulebookTypeLabel(Label):
+    name = StringProperty()
+
+
+Builder.load_string("""
+<RuleStepper>:
+    key_viewclass: 'widget'
+    RecycleGridLayout:
+        cols: 1
+""")

--- a/ELiDE/ELiDE/stepper.py
+++ b/ELiDE/ELiDE/stepper.py
@@ -74,10 +74,10 @@ class RuleStepperRuleButton(Button):
     set_tick = ObjectProperty()
 
     def on_release(self, *args):
-        if self.tick == self.start_tick:
-            self.set_tick(self.end_tick)
-        else:
+        if self.tick == self.end_tick:
             self.set_tick(self.start_tick)
+        else:
+            self.set_tick(self.end_tick)
 
 
 class EntityLabel(Label):

--- a/ELiDE/ELiDE/stepper.py
+++ b/ELiDE/ELiDE/stepper.py
@@ -122,6 +122,7 @@ Builder.load_string("""
         cols: 1
         size_hint_y: None
         default_size_hint: 1, None
+        default_height: 20
         height: self.minimum_height
 <RuleStepperRuleButton>:
     text: '\\n'.join((self.name, str(self.end_tick)))

--- a/ELiDE/ELiDE/stepper.py
+++ b/ELiDE/ELiDE/stepper.py
@@ -92,7 +92,7 @@ Builder.load_string("""
     text: self.name
     font_size: 14
     text_size: self.width, None
-    size: self.texture_size
+    height: self.texture_size[1] * 2
     halign: 'center'
 <EntityLabel>:
     multiline: True

--- a/ELiDE/ELiDE/stepper.py
+++ b/ELiDE/ELiDE/stepper.py
@@ -27,9 +27,9 @@ class RuleStepper(RecycleView):
             for tick, (entity, rulebook, rule) in rules.items():
                 if data:
                     prev = data[-1]
-                    assert prev['widget'] == 'RuleLabel'
-                    assert prev['end_tick'] is None
-                    prev['end_tick'] = tick - 1
+                    if prev['widget'] == 'RuleStepperRuleButton':
+                        assert prev['end_tick'] is None
+                        prev['end_tick'] = tick - 1
                 rulebook_per_entity = rbtyp in {'thing', 'place', 'portal'}
                 if not rulebook_per_entity:
                     if rulebook != last_rulebook:
@@ -52,20 +52,20 @@ class RuleStepper(RecycleView):
                             'name': rulebook
                         })
                 data.append({
-                    'widget': 'RuleLabel',
+                    'widget': 'RuleStepperRuleButton',
                     'name': rule,
                     'start_tick': tick,
                     'end_tick': None
                 })
             if data:
                 prev = data[-1]
-                assert prev['widget'] == 'RuleLabel'
+                assert prev['widget'] == 'RuleStepperRuleButton'
                 assert prev['end_tick'] is None
                 prev['end_tick'] = tick - 1
         self.data = data
 
 
-class RuleButton(Button):
+class RuleStepperRuleButton(Button):
     name = StringProperty()
     start_tick = NumericProperty()
     end_tick = NumericProperty()
@@ -88,4 +88,6 @@ Builder.load_string("""
     key_viewclass: 'widget'
     RecycleGridLayout:
         cols: 1
+<RuleStepperRuleButton>:
+    text: self.name
 """)

--- a/ELiDE/ELiDE/stepper.py
+++ b/ELiDE/ELiDE/stepper.py
@@ -69,6 +69,14 @@ class RuleStepperRuleButton(Button):
     name = StringProperty()
     start_tick = NumericProperty()
     end_tick = NumericProperty()
+    tick = NumericProperty()
+    set_tick = ObjectProperty()
+
+    def on_release(self, *args):
+        if self.tick == self.start_tick:
+            self.set_tick(self.end_tick)
+        else:
+            self.set_tick(self.start_tick)
 
 
 class EntityLabel(Label):
@@ -88,12 +96,22 @@ Builder.load_string("""
     key_viewclass: 'widget'
     RecycleGridLayout:
         cols: 1
+        size_hint_y: None
+        default_size_hint: 1, None
+        height: self.minimum_height
 <RuleStepperRuleButton>:
     text: self.name
     font_size: 14
     text_size: self.width, None
     height: self.texture_size[1] * 2
     halign: 'center'
+    tick: app.tick
+    set_tick: app.set_tick
+    canvas:
+        Color:
+            rgba: (1, 0, 0, 1) if self.tick in (self.start_tick, self.end_tick) else (0, 0, 0, 0)
+        Line:
+            points: [self.x, self.y + self.height, self.x + self.width, self.top] if app.tick == self.start_tick else [self.x, self.y, self.x + self.width, self.y]
 <EntityLabel>:
     multiline: True
     text: str(self.name)

--- a/LiSE/LiSE/cache.py
+++ b/LiSE/LiSE/cache.py
@@ -246,7 +246,7 @@ class RulesHandledCache(object):
     def __init__(self, engine):
         self.engine = engine
         self.handled = {}
-        self.handled_deep = StructuredDefaultDict(2, type=WindowDict)
+        self.handled_deep = StructuredDefaultDict(1, type=WindowDict)
         self.unhandled = {}
 
     def get_rulebook(self, *args):

--- a/LiSE/LiSE/cache.py
+++ b/LiSE/LiSE/cache.py
@@ -17,6 +17,7 @@ from .allegedb.cache import (
     PickyDefaultDict,
     StructuredDefaultDict,
     TurnDict,
+    WindowDict,
     HistoryError
 )
 from .util import singleton_get, sort_set
@@ -245,7 +246,7 @@ class RulesHandledCache(object):
     def __init__(self, engine):
         self.engine = engine
         self.handled = {}
-        self.handled_deep = StructuredDefaultDict(2)
+        self.handled_deep = StructuredDefaultDict(2, type=WindowDict)
         self.unhandled = {}
 
     def get_rulebook(self, *args):

--- a/LiSE/LiSE/engine.py
+++ b/LiSE/LiSE/engine.py
@@ -19,6 +19,7 @@ flow of time.
 """
 from functools import partial
 from collections import defaultdict
+from collections.abc import Mapping
 from operator import attrgetter
 from types import FunctionType, MethodType
 from abc import ABC, abstractmethod
@@ -231,7 +232,7 @@ class AbstractEngine(object):
                 typ = type(obj)
             if typ in handlers:
                 return handlers[typ](obj)
-            elif isinstance(obj, dict):
+            elif isinstance(obj, Mapping):
                 return dict(obj)
             raise TypeError("Can't pack {}".format(typ))
         packer = partial(

--- a/LiSE/LiSE/engine.py
+++ b/LiSE/LiSE/engine.py
@@ -231,6 +231,8 @@ class AbstractEngine(object):
                 typ = type(obj)
             if typ in handlers:
                 return handlers[typ](obj)
+            elif isinstance(obj, dict):
+                return dict(obj)
             raise TypeError("Can't pack {}".format(typ))
         packer = partial(
             msgpack.packb,

--- a/LiSE/LiSE/engine.py
+++ b/LiSE/LiSE/engine.py
@@ -521,9 +521,6 @@ class Engine(AbstractEngine, gORM):
       objects, but this one *is* sensitive to sim-time. Each turn, the
       state of the randomizer is saved here under the key
       ``'rando_state'``.
-    - ``keep_rules_journal``: Boolean; if true (default), keep
-      information on the behavior of the rules engine in the database.
-      Makes the database rather large, but useful for debugging.
 
     """
     from .character import Character
@@ -1064,6 +1061,9 @@ class Engine(AbstractEngine, gORM):
         loading the game
         :arg clear: whether to delete *any and all* existing data
         and code in ``prefix``. Use with caution!
+        :arg keep_rules_journal: Boolean; if true (default), keep
+        information on the behavior of the rules engine in the database.
+        Makes the database rather large, but useful for debugging.
 
         """
         import os

--- a/LiSE/LiSE/engine.py
+++ b/LiSE/LiSE/engine.py
@@ -585,7 +585,7 @@ class Engine(AbstractEngine, gORM):
         from .allegedb.window import update_window, update_backward_window
         if turn_from == turn_to:
             return self.get_turn_delta(
-                branch, turn_to, tick_to,start_tick=tick_from)
+                branch, turn_to, tick_to, start_tick=tick_from)
         delta = super().get_delta(
             branch, turn_from, tick_from, turn_to, tick_to)
         if turn_from < turn_to:
@@ -744,90 +744,117 @@ class Engine(AbstractEngine, gORM):
         turn = turn or self.turn
         tick = tick or self.tick
         delta = super().get_turn_delta(branch, turn, start_tick, tick)
-        if branch in self._avatarness_cache.settings \
-                and turn in self._avatarness_cache.settings[branch]:
-            for chara, graph, node, is_av in self._avatarness_cache.settings[
+        if start_tick < tick:
+            avatarness_settings = self._avatarness_cache.settings
+            things_settings = self._things_cache.settings
+            rulebooks_settings = self._rulebooks_cache.settings
+            triggers_settings = self._triggers_cache.settings
+            prereqs_settings = self._prereqs_cache.settings
+            actions_settings = self._actions_cache.settings
+            character_rulebooks_settings = self._characters_rulebooks_cache.settings
+            avatar_rulebooks_settings = self._avatars_rulebooks_cache.settings
+            character_thing_rulebooks_settings = self._characters_things_rulebooks_cache.settings
+            character_place_rulebooks_settings = self._characters_places_rulebooks_cache.settings
+            character_portal_rulebooks_settings = self._characters_portals_rulebooks_cache.settings
+            node_rulebooks_settings = self._nodes_rulebooks_cache.settings
+            portal_rulebooks_settings = self._portals_rulebooks_cache.settings
+        else:
+            avatarness_settings = self._avatarness_cache.presettings
+            things_settings = self._things_cache.presettings
+            rulebooks_settings = self._rulebooks_cache.presettings
+            triggers_settings = self._triggers_cache.presettings
+            prereqs_settings = self._prereqs_cache.presettings
+            actions_settings = self._actions_cache.presettings
+            character_rulebooks_settings = self._characters_rulebooks_cache.presettings
+            avatar_rulebooks_settings = self._avatars_rulebooks_cache.presettings
+            character_thing_rulebooks_settings = self._characters_things_rulebooks_cache.presettings
+            character_place_rulebooks_settings = self._characters_places_rulebooks_cache.presettings
+            character_portal_rulebooks_settings = self._characters_portals_rulebooks_cache.presettings
+            node_rulebooks_settings = self._nodes_rulebooks_cache.presettings
+            portal_rulebooks_settings = self._portals_rulebooks_cache.presettings
+        if branch in avatarness_settings \
+                and turn in avatarness_settings[branch]:
+            for chara, graph, node, is_av in avatarness_settings[
                         branch][turn][start_tick:tick]:
                 delta.setdefault(chara, {}).setdefault(
                     'avatars', {}).setdefault(graph, {})[node] = is_av
-        if branch in self._things_cache.settings \
-                and turn in self._things_cache.settings[branch]:
-            for chara, thing, location in self._things_cache.settings[
+        if branch in things_settings \
+                and turn in things_settings[branch]:
+            for chara, thing, location in things_settings[
                                               branch][turn][start_tick:tick]:
                 thingd = delta.setdefault(chara, {}).setdefault(
                     'node_val', {}).setdefault(thing, {})
                 thingd['location'] = location
         delta['rulebooks'] = rbdif = {}
-        if branch in self._rulebooks_cache.settings \
-                and turn in self._rulebooks_cache.settings[branch]:
-            for _, rulebook, rules in self._rulebooks_cache.settings[
+        if branch in rulebooks_settings \
+                and turn in rulebooks_settings[branch]:
+            for _, rulebook, rules in rulebooks_settings[
                                           branch][turn][start_tick:tick]:
                 rbdif[rulebook] = rules
         delta['rules'] = rdif = {}
-        if branch in self._triggers_cache.settings \
-                and turn in self._triggers_cache.settings[branch]:
-            for _, rule, funs in self._triggers_cache.settings[
+        if branch in triggers_settings \
+                and turn in triggers_settings[branch]:
+            for _, rule, funs in triggers_settings[
                                      branch][turn][start_tick:tick]:
                 rdif.setdefault(rule, {})['triggers'] = funs
-        if branch in self._prereqs_cache.settings \
-                and turn in self._prereqs_cache.settings[branch]:
-            for _, rule, funs in self._prereqs_cache.settings[
+        if branch in prereqs_settings \
+                and turn in prereqs_settings[branch]:
+            for _, rule, funs in prereqs_settings[
                                      branch][turn][start_tick:tick]:
                 rdif.setdefault(rule, {})['prereqs'] = funs
-        if branch in self._actions_cache.settings \
-                and turn in self._triggers_cache.settings[branch]:
-            for _, rule, funs in self._triggers_cache.settings[
+        if branch in actions_settings \
+                and turn in actions_settings[branch]:
+            for _, rule, funs in actions_settings[
                                      branch][turn][start_tick:tick]:
                 rdif.setdefault(rule, {})['actions'] = funs
 
-        if branch in self._characters_rulebooks_cache.settings \
-                and turn in self._characters_rulebooks_cache.settings[branch]:
+        if branch in character_rulebooks_settings \
+                and turn in character_rulebooks_settings[branch]:
             for _, character, rulebook in \
-                    self._characters_rulebooks_cache.settings[
+                    character_rulebooks_settings[
                         branch][turn][start_tick:tick]:
                 delta.setdefault(
                     character, {})['character_rulebook'] = rulebook
-        if branch in self._avatars_rulebooks_cache.settings \
-                and turn in self._avatars_rulebooks_cache.settings[branch]:
+        if branch in avatar_rulebooks_settings \
+                and turn in avatar_rulebooks_settings[branch]:
             for _, character, rulebook in \
-                    self._avatars_rulebooks_cache.settings[
+                    avatar_rulebooks_settings[
                         branch][turn][start_tick:tick]:
                 delta.setdefault(character, {})['avatar_rulebook'] = rulebook
-        if branch in self._characters_things_rulebooks_cache.settings \
-                and turn in self._characters_things_rulebooks_cache.settings[
+        if branch in character_thing_rulebooks_settings \
+                and turn in character_thing_rulebooks_settings[
                     branch]:
             for _, character, rulebook in \
-                    self._characters_things_rulebooks_cache.settings[
+                    character_thing_rulebooks_settings[
                         branch][turn][start_tick:tick]:
                 delta.setdefault(
                     character, {})['character_thing_rulebook'] = rulebook
-        if branch in self._characters_places_rulebooks_cache.settings \
-                and turn in self._characters_places_rulebooks_cache.settings[
-                    branch]:
+        if branch in character_place_rulebooks_settings \
+                and turn in character_place_rulebooks_settings[branch]:
             for _, character, rulebook in \
-                    self._characters_places_rulebooks_cache.settings[
+                    character_place_rulebooks_settings[
                         branch][turn][start_tick:tick]:
                 delta.setdefault(
                     character, {})['character_place_rulebook'] = rulebook
-        if branch in self._characters_portals_rulebooks_cache.settings \
-                and turn in self._characters_portals_rulebooks_cache.settings[
+        if branch in character_portal_rulebooks_settings \
+                and turn in character_portal_rulebooks_settings[
                     branch]:
             for _, character, rulebook in \
-                    self._characters_portals_rulebooks_cache.settings[
+                    character_portal_rulebooks_settings[
                         branch][turn][start_tick:tick]:
                 delta.setdefault(character, {})['character_portal_rulebook'] = rulebook
 
-        if branch in self._nodes_rulebooks_cache.settings \
-                and turn in self._nodes_rulebooks_cache.settings[branch]:
+        if branch in node_rulebooks_settings \
+                and turn in node_rulebooks_settings[branch]:
             for character, node, rulebook in \
-                    self._nodes_rulebooks_cache.settings[
+                    node_rulebooks_settings[
                         branch][turn][start_tick:tick]:
                 delta.setdefault(character, {}).setdefault(
                     'node_val', {}).setdefault(node, {})['rulebook'] = rulebook
-        if branch in self._portals_rulebooks_cache.settings \
-                and turn in self._portals_rulebooks_cache.settings[branch]:
+        if branch in portal_rulebooks_settings \
+                and turn in portal_rulebooks_settings[branch]:
             for character, orig, dest, rulebook in \
-                    self._portals_rulebooks_cache.settings[
+                    portal_rulebooks_settings[
                         branch][turn][start_tick:tick]:
                 delta.setdefault(character, {}).setdefault('edge_val', {}) \
                     .setdefault(orig, {}).setdefault(dest, {})[

--- a/LiSE/LiSE/engine.py
+++ b/LiSE/LiSE/engine.py
@@ -1017,9 +1017,11 @@ class Engine(AbstractEngine, gORM):
         :arg alchemy: whether to use SQLAlchemy to connect to the
         database. If False, LiSE can only use SQLite
         :arg flush_modulus: LiSE will put pending changes into the database
-        transaction every ``flush_modulus`` turns
+        transaction every ``flush_modulus`` turns, default 1. If `None`,
+        only flush on commit
         :arg commit_modulus: LiSE will commit changes to disk every
-        ``commit_modulus`` turns
+        ``commit_modulus`` turns, default 10. If `None`, only commit
+        on close or manual call to `commit`
         :arg random_seed: a number to initialize the randomizer
         :arg logfun: an optional function taking arguments
         ``level, message``, which should log `message` somehow

--- a/LiSE/LiSE/engine.py
+++ b/LiSE/LiSE/engine.py
@@ -112,7 +112,8 @@ class NextTurn(Signal):
                         tick_to=tick
                     )
         engine._turns_completed[start_branch] = engine.turn
-        engine.query.complete_turn(start_branch, engine.turn)
+        if not self.engine.keep_rules_journal:
+            engine.query.complete_turn(start_branch, engine.turn)
         if engine.flush_modulus and engine.turn % engine.flush_modulus == 0:
             engine.query.flush()
         if engine.commit_modulus and engine.turn % engine.commit_modulus == 0:
@@ -520,6 +521,9 @@ class Engine(AbstractEngine, gORM):
       objects, but this one *is* sensitive to sim-time. Each turn, the
       state of the randomizer is saved here under the key
       ``'rando_state'``.
+    - ``keep_rules_journal``: Boolean; if true (default), keep
+      information on the behavior of the rules engine in the database.
+      Makes the database rather large, but useful for debugging.
 
     """
     from .character import Character
@@ -1016,7 +1020,8 @@ class Engine(AbstractEngine, gORM):
             random_seed=None,
             logfun=None,
             validate=False,
-            clear=False
+            clear=False,
+            keep_rules_journal=True
     ):
         """Store the connections for the world database and the code database;
         set up listeners; and start a transaction
@@ -1063,6 +1068,7 @@ class Engine(AbstractEngine, gORM):
         """
         import os
         from .xcollections import StringStore
+        self.keep_rules_journal = keep_rules_journal
         self.exist_node_time = 0
         self.exist_edge_time = 0
         if string:

--- a/LiSE/LiSE/engine.py
+++ b/LiSE/LiSE/engine.py
@@ -21,7 +21,9 @@ from functools import partial
 from collections import defaultdict
 from collections.abc import Mapping
 from operator import attrgetter
-from types import FunctionType, MethodType
+from types import FunctionType, MethodType, ModuleType
+from typing import Type, Union
+from os import PathLike
 from abc import ABC, abstractmethod
 
 import msgpack
@@ -30,6 +32,7 @@ from .allegedb import ORM as gORM
 from .allegedb import HistoryError
 from .reify import reify
 from .util import sort_set
+from .xcollections import StringStore, FunctionStore, MethodStore
 
 from . import exc
 
@@ -1000,22 +1003,22 @@ class Engine(AbstractEngine, gORM):
 
     def __init__(
             self,
-            prefix='.',
+            prefix: PathLike = '.',
             *,
-            string=None,
-            trigger=None,
-            prereq=None,
-            action=None,
-            function=None,
-            method=None,
-            connect_string=None,
-            connect_args={},
-            schema_cls=NullSchema,
+            string: Union[StringStore, dict] = None,
+            trigger: Union[FunctionStore, ModuleType] = None,
+            prereq: Union[FunctionStore, ModuleType] = None,
+            action: Union[FunctionStore, ModuleType] = None,
+            function: Union[FunctionStore, ModuleType] = None,
+            method: Union[MethodStore, ModuleType] = None,
+            connect_string: str = None,
+            connect_args: dict = None,
+            schema_cls: Type[AbstractSchema] = NullSchema,
             alchemy=False,
             flush_modulus=1,
             commit_modulus=10,
-            random_seed=None,
-            logfun=None,
+            random_seed: int = None,
+            logfun: FunctionType = None,
             validate=False,
             clear=False,
             keep_rules_journal=True
@@ -1068,6 +1071,8 @@ class Engine(AbstractEngine, gORM):
         """
         import os
         from .xcollections import StringStore
+        if connect_args is None:
+            connect_args = {}
         self.keep_rules_journal = keep_rules_journal
         self.exist_node_time = 0
         self.exist_edge_time = 0

--- a/LiSE/LiSE/engine.py
+++ b/LiSE/LiSE/engine.py
@@ -1398,14 +1398,14 @@ class Engine(AbstractEngine, gORM):
                 if res:
                     return True
             else:
-                handled_fun()
+                handled_fun(self.tick)
                 return False
 
         def check_prereqs(rule, handled_fun, entity):
             for prereq in rule.prereqs:
                 res = prereq(entity)
                 if not res:
-                    handled_fun()
+                    handled_fun(self.tick)
                     return False
             return True
 
@@ -1415,7 +1415,7 @@ class Engine(AbstractEngine, gORM):
                 res = action(entity)
                 if res:
                     actres.append(res)
-            handled_fun()
+            handled_fun(self.tick)
             return actres
 
         # TODO: triggers that don't mutate anything should be
@@ -1430,7 +1430,7 @@ class Engine(AbstractEngine, gORM):
             rule = rulemap[rulename]
             handled = partial(
                 self._handled_char, charactername, rulebook, rulename,
-                branch, turn, tick)
+                branch, turn)
             entity = charmap[charactername]
             if check_triggers(rule, handled, entity):
                 todo[rulebook].append((rule, handled, entity))
@@ -1449,7 +1449,7 @@ class Engine(AbstractEngine, gORM):
             rule = rulemap[rulen]
             handled = partial(
                 self._handled_av, charn, graphn, avn, rulebook, rulen,
-                branch, turn, tick)
+                branch, turn)
             entity = get_node(graphn, avn)
             if check_triggers(rule, handled, entity):
                 todo[rulebook].append((rule, handled, entity))
@@ -1464,7 +1464,7 @@ class Engine(AbstractEngine, gORM):
             rule = rulemap[rulen]
             handled = partial(
                 handled_char_thing, charn, thingn, rulebook, rulen,
-                branch, turn, tick)
+                branch, turn)
             entity = get_node(charn, thingn)
             if check_triggers(rule, handled, entity):
                 todo[rulebook].append((rule, handled, entity))
@@ -1479,7 +1479,7 @@ class Engine(AbstractEngine, gORM):
             rule = rulemap[rulen]
             handled = partial(
                 handled_char_place, charn, placen, rulebook, rulen,
-                branch, turn, tick)
+                branch, turn)
             entity = get_node(charn, placen)
             if check_triggers(rule, handled, entity):
                 todo[rulebook].append((rule, handled, entity))
@@ -1496,7 +1496,7 @@ class Engine(AbstractEngine, gORM):
             rule = rulemap[rulen]
             handled = partial(
                 handled_char_port, charn, orign, destn, rulebook, rulen,
-                branch, turn, tick)
+                branch, turn)
             entity = get_edge(charn, orign, destn)
             if check_triggers(rule, handled, entity):
                 todo[rulebook].append((rule, handled, entity))
@@ -1511,7 +1511,7 @@ class Engine(AbstractEngine, gORM):
             rule = rulemap[rulen]
             handled = partial(
                 handled_node, charn, noden, rulebook, rulen,
-                branch, turn, tick)
+                branch, turn)
             entity = get_node(charn, noden)
             if check_triggers(rule, handled, entity):
                 todo[rulebook].append((rule, handled, entity))
@@ -1526,7 +1526,7 @@ class Engine(AbstractEngine, gORM):
             rule = rulemap[rulen]
             handled = partial(
                 handled_portal, charn, orign, destn, rulebook, rulen,
-                branch, turn, tick)
+                branch, turn)
             entity = get_edge(charn, orign, destn)
             if check_triggers(rule, handled, entity):
                 todo[rulebook].append((rule, handled, entity))

--- a/LiSE/LiSE/handle.py
+++ b/LiSE/LiSE/handle.py
@@ -1299,6 +1299,7 @@ class EngineHandle(object):
         if turn is None:
             turn = self.turn
         eng = self._real
+        # assume the caches are all sync'd
         return {
             'character': eng._character_rules_handled_cache.handled_deep[branch
             ][turn],


### PR DESCRIPTION
Adds a new feature to ELiDE that lets you look at a list of rules in a given turn and time warp to just after a given one.

Fixes time travel within a turn when you're going backwards.

Databases now store the times each rule was completed, unless you disable this.